### PR TITLE
chore(meta): sync skills and add db truth rule

### DIFF
--- a/.agents/.skill-lock.json
+++ b/.agents/.skill-lock.json
@@ -9,6 +9,15 @@
       "skillFolderHash": "c2f31172b6f256272305a5e6e7228b258446899f",
       "installedAt": "2026-03-10T05:28:40.020Z",
       "updatedAt": "2026-03-10T05:28:40.020Z"
+    },
+    "caveman": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/JuliusBrussee/caveman.git",
+      "skillPath": "caveman/SKILL.md",
+      "skillFolderHash": "3e5091e2f32acef06ba3540770ecf7f87e5db25c",
+      "installedAt": "2026-04-06T15:33:00.927Z",
+      "updatedAt": "2026-04-06T15:33:00.927Z"
     }
   },
   "dismissed": {
@@ -16,13 +25,17 @@
   },
   "lastSelectedAgents": [
     "amp",
+    "antigravity",
     "cline",
     "codex",
     "cursor",
+    "deepagents",
+    "firebender",
     "gemini-cli",
     "github-copilot",
     "kimi-cli",
     "opencode",
+    "warp",
     "claude-code"
   ]
 }

--- a/.agents/skills/caveman/SKILL.md
+++ b/.agents/skills/caveman/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Slash token usage ~75% by speaking like caveman
+  while keeping full technical accuracy. Use when user says "caveman mode", "talk like caveman",
+  "use caveman", "less tokens", "be brief", or invokes /caveman. Also auto-triggers
+  when token efficiency is requested.
+---
+
+# Caveman Mode
+
+## Core Rule
+
+Respond like smart caveman. Cut articles, filler, pleasantries. Keep all technical substance.
+
+## Grammar
+
+- Drop articles (a, an, the)
+- Drop filler (just, really, basically, actually, simply)
+- Drop pleasantries (sure, certainly, of course, happy to)
+- Short synonyms (big not extensive, fix not "implement a solution for")
+- No hedging (skip "it might be worth considering")
+- Fragments fine. No need full sentence
+- Technical terms stay exact. "Polymorphism" stays "polymorphism"
+- Code blocks unchanged. Caveman speak around code, not in code
+- Error messages quoted exact. Caveman only for explanation
+
+## Pattern
+
+```
+[thing] [action] [reason]. [next step].
+```
+
+Not:
+> Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by...
+
+Yes:
+> Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:
+
+## Examples
+
+**User:** Why is my React component re-rendering?
+
+**Normal (69 tokens):** "The reason your React component is re-rendering is likely because you're creating a new object reference on each render cycle. When you pass an inline object as a prop, React's shallow comparison sees it as a different object every time, which triggers a re-render. I'd recommend using useMemo to memoize the object."
+
+**Caveman (19 tokens):** "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+
+---
+
+**User:** How do I set up a PostgreSQL connection pool?
+
+**Caveman:**
+```
+Use `pg` pool:
+```
+```js
+const pool = new Pool({
+  max: 20,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000,
+})
+```
+```
+max = concurrent connections. Keep under DB limit. idleTimeout kill stale conn.
+```
+
+## Boundaries
+
+- Code: write normal. Caveman English only
+- Git commits: normal
+- PR descriptions: normal
+- User say "stop caveman" or "normal mode": revert immediately

--- a/.cursor/rules/meta/database-single-source-of-truth.mdc
+++ b/.cursor/rules/meta/database-single-source-of-truth.mdc
@@ -1,0 +1,77 @@
+# Database Single Source of Truth
+
+When working on data modeling, fixtures, seeds, migrations, or test data, default to one canonical database path that both runtime and tests use.
+
+## When This Applies
+
+- Any work touching SQL migrations, schema design, or seed data
+- Any request to add or modify test/mock/demo data
+- Any change where runtime and tests both depend on DB-backed records
+- Any refactor removing TS/JSON fixture catalogs
+
+## Core Principles
+
+### 1) One Canonical Read Path
+
+- Runtime and tests must read from the same canonical tables/views.
+- Do not create parallel TS catalogs for data already represented in DB rows.
+- If API returns DB-backed objects, tests should validate against those same DB objects.
+
+### 2) One Canonical Write Path
+
+- Canonical data should be authored and seeded through migrations (or migration-owned SQL scripts).
+- Avoid seeding the same canonical dataset in multiple ways (TS constants + SQL + ad hoc script).
+- If a generator input exists (for example JSON), it must be clearly non-runtime and have a single deterministic export path.
+
+### 3) Reuse Before Creation
+
+- Before creating new table/view/function/trigger, prove why existing schema objects cannot satisfy the requirement.
+- Prefer extending existing domain objects over introducing new "helper" schema for implementation convenience.
+- New objects must be justified by a concrete domain need, not by temporary fixture mechanics.
+
+### 4) Domain-First Naming
+
+- Canonical schema object names should reflect domain meaning.
+- Avoid implementation-detail naming in canonical objects (`fixture`, `mock`, `testdata`, etc.) unless the object is explicitly ephemeral and non-canonical.
+- If migration compatibility requires temporary aliases, remove them in a follow-up migration and document the deprecation path.
+
+## Implementation Guidelines
+
+When implementing DB/data changes, follow this order:
+
+1. Identify the canonical runtime read path.
+2. Confirm tests can read from that same path.
+3. Verify existing schema sufficiency before adding objects.
+4. Implement migration changes for canonical data only.
+5. Remove duplicated seed/catalog sources (TS constants, stale snapshots, duplicate scripts).
+6. Verify runtime + tests both pass using the same canonical DB path.
+
+## Acceptance Checklist
+
+- [ ] Runtime and tests read the same canonical tables/views
+- [ ] No duplicate canonical seeding path introduced
+- [ ] New schema objects (if any) justified with reuse-first analysis
+- [ ] Canonical object names are domain-first, not implementation-first
+- [ ] Temporary compatibility objects are documented and scheduled for removal
+
+## Prefer / Avoid
+
+### Prefer
+
+- "Seed canonical rows in migration; endpoint and tests query same table/view."
+- "Reuse existing domain table and add one column/index needed for behavior."
+
+### Avoid
+
+- "Keep runtime data in DB, but maintain a second TS fixture list for tests."
+- "Create new schema named by implementation detail when existing domain objects can serve."
+- "Seed identical canonical data via multiple independent scripts."
+
+## Related Artifacts
+
+- [MVP-First Rule](.cursor/rules/meta/mvp-first.mdc)
+- [YAGNI Rule](.cursor/rules/meta/yagni.mdc)
+- [Verify-Before-Done Rule](.cursor/rules/meta/verify-before-done.mdc)
+- [Artifact Creation Rule](.cursor/rules/meta/artifact-creation.mdc)
+- [Documentation Rule](.cursor/rules/meta/documentation.mdc)
+- [Organization Rule](.cursor/rules/meta/organization.mdc)

--- a/.cursor/skills/brainstorming--de6f87c50c
+++ b/.cursor/skills/brainstorming--de6f87c50c
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/brainstorming--de6f87c50c

--- a/.cursor/skills/command-creator
+++ b/.cursor/skills/command-creator
@@ -1,1 +1,0 @@
-../../.agents/skills/command-creator

--- a/.cursor/skills/cursor-best-practices
+++ b/.cursor/skills/cursor-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/cursor-best-practices

--- a/.cursor/skills/deslop--739b5c8904
+++ b/.cursor/skills/deslop--739b5c8904
@@ -1,0 +1,1 @@
+/home/hutchic/github.com/surefirev2/paperclip-ops/company-skills/deslop

--- a/.cursor/skills/dispatching-parallel-agents--db299a41cb
+++ b/.cursor/skills/dispatching-parallel-agents--db299a41cb
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/dispatching-parallel-agents--db299a41cb

--- a/.cursor/skills/ensure-feature-branch--d7df84b0dd
+++ b/.cursor/skills/ensure-feature-branch--d7df84b0dd
@@ -1,0 +1,1 @@
+/home/hutchic/github.com/surefirev2/paperclip-ops/company-skills/ensure-feature-branch

--- a/.cursor/skills/executing-plans--ea7c077b30
+++ b/.cursor/skills/executing-plans--ea7c077b30
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/executing-plans--ea7c077b30

--- a/.cursor/skills/find-skills
+++ b/.cursor/skills/find-skills
@@ -1,1 +1,0 @@
-../../.agents/skills/find-skills

--- a/.cursor/skills/finishing-a-development-branch--25d0808e36
+++ b/.cursor/skills/finishing-a-development-branch--25d0808e36
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/finishing-a-development-branch--25d0808e36

--- a/.cursor/skills/gh-cli--2f71fb3065
+++ b/.cursor/skills/gh-cli--2f71fb3065
@@ -1,0 +1,1 @@
+/tmp/paperclip-worktree-rebalance-dusSMH/.paperclip-worktrees/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/gh-cli--2f71fb3065

--- a/.cursor/skills/karpathy-guidelines
+++ b/.cursor/skills/karpathy-guidelines
@@ -1,1 +1,0 @@
-../../.agents/skills/karpathy-guidelines

--- a/.cursor/skills/logging-best-practices
+++ b/.cursor/skills/logging-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/logging-best-practices

--- a/.cursor/skills/open-pr--4ddef8fd78
+++ b/.cursor/skills/open-pr--4ddef8fd78
@@ -1,0 +1,1 @@
+/home/hutchic/github.com/surefirev2/paperclip-ops/company-skills/open-pr

--- a/.cursor/skills/paperclip
+++ b/.cursor/skills/paperclip
@@ -1,0 +1,1 @@
+/home/hutchic/.npm/_npx/4cc26c48ea9243e4/node_modules/@paperclipai/server/skills/paperclip

--- a/.cursor/skills/paperclip-create-agent
+++ b/.cursor/skills/paperclip-create-agent
@@ -1,0 +1,1 @@
+/home/hutchic/.npm/_npx/4cc26c48ea9243e4/node_modules/@paperclipai/server/skills/paperclip-create-agent

--- a/.cursor/skills/paperclip-create-plugin
+++ b/.cursor/skills/paperclip-create-plugin
@@ -1,0 +1,1 @@
+/home/hutchic/.npm/_npx/4cc26c48ea9243e4/node_modules/@paperclipai/server/skills/paperclip-create-plugin

--- a/.cursor/skills/para-memory-files
+++ b/.cursor/skills/para-memory-files
@@ -1,0 +1,1 @@
+/home/hutchic/.npm/_npx/4cc26c48ea9243e4/node_modules/@paperclipai/server/skills/para-memory-files

--- a/.cursor/skills/receiving-code-review--5a6d570ad1
+++ b/.cursor/skills/receiving-code-review--5a6d570ad1
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/receiving-code-review--5a6d570ad1

--- a/.cursor/skills/requesting-code-review--5dd641c87a
+++ b/.cursor/skills/requesting-code-review--5dd641c87a
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/requesting-code-review--5dd641c87a

--- a/.cursor/skills/shipit--7ceabd202a
+++ b/.cursor/skills/shipit--7ceabd202a
@@ -1,0 +1,1 @@
+/home/hutchic/github.com/surefirev2/paperclip-ops/company-skills/shipit

--- a/.cursor/skills/skill-creator
+++ b/.cursor/skills/skill-creator
@@ -1,1 +1,0 @@
-../../.agents/skills/skill-creator

--- a/.cursor/skills/stage-related-files--622f8f6724
+++ b/.cursor/skills/stage-related-files--622f8f6724
@@ -1,0 +1,1 @@
+/home/hutchic/github.com/surefirev2/paperclip-ops/company-skills/stage-related-files

--- a/.cursor/skills/subagent-driven-development--c7f2c63abc
+++ b/.cursor/skills/subagent-driven-development--c7f2c63abc
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/subagent-driven-development--c7f2c63abc

--- a/.cursor/skills/systematic-debugging--d9a83639ff
+++ b/.cursor/skills/systematic-debugging--d9a83639ff
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/systematic-debugging--d9a83639ff

--- a/.cursor/skills/test-driven-development
+++ b/.cursor/skills/test-driven-development
@@ -1,1 +1,0 @@
-../../.agents/skills/test-driven-development

--- a/.cursor/skills/test-driven-development--f22c9c9eef
+++ b/.cursor/skills/test-driven-development--f22c9c9eef
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/test-driven-development--f22c9c9eef

--- a/.cursor/skills/using-git-worktrees--058ef2390a
+++ b/.cursor/skills/using-git-worktrees--058ef2390a
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/using-git-worktrees--058ef2390a

--- a/.cursor/skills/using-superpowers--9ed33a2ead
+++ b/.cursor/skills/using-superpowers--9ed33a2ead
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/using-superpowers--9ed33a2ead

--- a/.cursor/skills/verification-before-completion--a42c12e610
+++ b/.cursor/skills/verification-before-completion--a42c12e610
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/verification-before-completion--a42c12e610

--- a/.cursor/skills/writing-plans--4276e6d5cb
+++ b/.cursor/skills/writing-plans--4276e6d5cb
@@ -1,0 +1,1 @@
+/home/hutchic/.paperclip/instances/default/skills/7e57597f-4778-487c-aaeb-de0b2765d267/__runtime__/writing-plans--4276e6d5cb

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Rules that guide the self-improvement process (always applied):
 - `documentation` - Documentation standards
 - `artifact-creation` - Decision framework for creating artifacts
 - `automation-decomposition` - Decompose automations into discrete skills, then package into commands
+- `database-single-source-of-truth` - Keep runtime/tests on one canonical DB path with one canonical seed path
 
 ### Meta Subagents
 
@@ -122,7 +123,7 @@ The system can analyze conversations, extract patterns, and create new artifacts
 
 - `.cursor/` - All Cursor artifacts (used directly by Cursor IDE)
   - `rules/` - Cursor rules (see [docs/cursor-rules.md](docs/cursor-rules.md))
-    - `meta/` - Meta rules for self-improvement (organization, cross-referencing, documentation, artifact-creation, automation-decomposition)
+    - `meta/` - Meta rules for self-improvement (organization, cross-referencing, documentation, artifact-creation, automation-decomposition, database-single-source-of-truth)
     - `organization/` - Organization-specific rules
     - `hello-world.mdc` - Example rule demonstrating rule structure
     - `self-improvement.mdc` - Self-improvement guidance

--- a/cursor_fixture_data_unification_for_dri.md
+++ b/cursor_fixture_data_unification_for_dri.md
@@ -1,0 +1,223 @@
+# Fixture data unification for drizzle migrations
+_Exported on 07/04/2026 at 8:42:53 GMT-4 from Cursor (3.0.12)_
+
+---
+
+**User**
+
+let's continue to unify all fixture data to the drizzle migrations. For example what is @shared/hockeymind/teams.ts ?
+
+---
+
+**Cursor**
+
+Got it. I’m going to inspect `shared/hockeymind/teams.ts` and the surrounding schema/fixture wiring, then explain exactly what it is today (source-of-truth, who imports it, and how it relates to Drizzle migrations) and outline the concrete next migration step to fold it into SQL fixtures.
+
+Next I’m going to find where `TEAM_OPTIONS` / `FIXTURE_TEAM_SEED_SLUGS` are imported, so we can decide whether this file is acting as a second “fixture source” (bad) or just a UI convenience that can be derived from DB rows (preferred) before we migrate/delete it.
+
+## What is `shared/hockeymind/teams.ts`?
+
+It’s a **small “fixture selector” module** that hard-codes:
+
+- **`FIXTURE_TEAM_SEED_SLUGS`**: the ordered list of team **seed slugs** (stable keys that match `hockey_team.slug`) that the app considers part of the _fixture library_.
+- **`TEAM_OPTIONS`**: a parallel list of `{ slug, name }` used as **human-facing labels** (and referenced by tests).
+- **`TeamSeedSlug`**: a TS type derived from `TEAM_OPTIONS`.
+
+You can see the intent right in the header:
+
+```1:33:shared/hockeymind/teams.ts
+/**
+ * Team compositions available in the tracer UI (seed keys match `hockey_team.slug`).
+ * Public URLs and chat `teamId` use `hockey_team.id` (UUID); `slug` is the stable seed key.
+ * Keep in sync with fixture rows delivered by migrations — see integration tests.
+ */
+export const FIXTURE_TEAM_SEED_SLUGS = [
+  'balanced',
+  'fast-defense',
+  'fast-forwards',
+  'weak-passing'
+] as const
+
+export const TEAM_OPTIONS = [
+  { slug: 'balanced', name: 'Eastgate U15 — Balanced depth' },
+  { slug: 'fast-defense', name: 'Northside U15 — Structure first' },
+  { slug: 'fast-forwards', name: 'River Valley U15 — Pace offense' },
+  { slug: 'weak-passing', name: 'South County U13 — Weak passing' }
+] as const
+```
+
+### Why it matters for “unify fixtures into migrations”
+
+Right now this file is effectively a **second source of truth for “which fixture teams exist” and “what their names are”**, because it’s used in **runtime routing** and **tests**:
+
+- **Runtime API uses it to filter DB rows**:
+
+```3:41:server/api/teams/fixture-library.get.ts
+import { FIXTURE_TEAM_SEED_SLUGS } from '../../../shared/hockeymind/teams'
+// ...
+.where(inArray(hockeyTeam.slug, [...FIXTURE_TEAM_SEED_SLUGS]))
+```
+
+- **Unit test imports `TEAM_OPTIONS`** (`tests/hockeymind-teams.test.ts`)
+- **E2E test hard-codes labels that “match `TEAM_OPTIONS[...]`”** (`e2e/j2_team_switch_clears_session.test.ts`)
+
+So even if migrations are the _only_ writer, we still have a **parallel “catalog”** living in TS that can drift from what migrations insert.
+
+### The direction to finish the unification
+
+To make migrations the single authoritative place, the app should **derive** these lists from the database fixture rows (and/or query by an explicit DB flag like “is_fixture_library”), rather than enumerating slugs in TS.
+
+If you want, next I can implement the first slice: replace `FIXTURE_TEAM_SEED_SLUGS` usage in `server/api/teams/fixture-library.get.ts` with a DB-driven query (then update the tests that currently depend on those TS constants).
+
+---
+
+**User**
+
+draft a plan to nuke those ts fixture files. This data should be seeded via drizzle sql migrations and the application should use the database as it's source of truth.
+
+---
+
+**Cursor**
+
+I’ll inventory all TS-based fixture sources (like `shared/hockeymind/teams.ts`), map who imports them (API/UI/tests), and then propose a migration-first replacement plan (DB-driven queries + updated tests) so we can delete those files without losing functionality.
+
+Next I’ll read the other TS “fixture-ish” modules (`drillLibraryV1`, `tracerContext`, `teamRosterStatic`) plus the existing SQL fixture seed(s). That will let us define exactly what gets migrated into SQL and what becomes DB-driven queries so we can delete TS catalogs cleanly.
+
+**Fixture unification decisions**
+
+> **To eliminate hard-coded slug lists in TS, should we add a DB marker on `hockey_team` (e.g. `is_fixture_library` + optional `fixture_sort_index`) and update the seed + grants trigger to use that, instead of `WHERE slug IN (...)`?**
+> - Yes — add `is_fixture_library` + `fixture_sort_index` and make app/SQL query by those columns.
+> - No — keep the list hard-coded in SQL migrations/triggers, just remove TS usage from the app. ✔
+>
+> **Scope-wise, are we only deleting TS fixture catalogs (like `shared/hockeymind/teams.ts`), or do you also want to remove the canonical JSON inputs under `data/teams/v1/` and `data/drills/v1/` (meaning fixtures would be authored directly as SQL)?**
+> - Delete TS fixture files only; keep JSON inputs (they’re not runtime sources).
+> - Move authoring fully to SQL; delete/stop using the JSON fixture inputs too. ✔
+
+---
+
+**User**
+
+Implement the plan as specified, it is attached for your reference. Do NOT edit the plan file itself.
+
+To-do's from the plan have already been created. Do not create them again. Mark them as in_progress as you work, starting with the first one. Don't stop until you have completed all the to-dos.
+
+---
+
+**Cursor**
+
+I’m going to implement this in three slices: first add the DB view and wire `0015` to it, then switch the runtime endpoint/tests off `shared/hockeymind/teams.ts` and delete that file, then finish the “SQL-only authoring” work by updating docs/provenance scripts and replacing the team offline snapshot with a DB-derived exporter.
+
+Next I’ll register these migrations in `drizzle/meta/_journal.json` so `drizzle-kit migrate` can pick them up, then I’ll move on to removing `shared/hockeymind/teams.ts` and switching the endpoint/tests to query the new `hockey_fixture_library_team` view.
+
+I’ve rewired `/api/teams/fixture-library` to read fixture membership from the new SQL view; next I’ll update the tests and E2E flows that referenced `TEAM_OPTIONS`/`FIXTURE_TEAM_SEED_SLUGS`, then delete `shared/hockeymind/teams.ts` and clean up any remaining imports.
+
+## What I changed (to “nuke TS fixture files” + DB-as-truth)
+
+### DB: fixture-library membership + grants are now SQL-defined
+- Added `drizzle/0017_hockey_fixture_library_team_view.sql` to define **fixture-library team membership + ordering** via `hockey_fixture_library_team` view.
+- Added `drizzle/0018_fixture_library_roster_access_grants_use_view.sql` to **backfill + trigger** roster `viewer` grants by selecting from that view (supersedes the slug-list logic in `0015`).
+- Registered both migrations in `drizzle/meta/_journal.json`.
+
+### Runtime: no TS fixture catalog
+- Updated `server/api/teams/fixture-library.get.ts` to return fixture teams by joining against `hockey_fixture_library_team` (ordered by `sort_index`).
+- Deleted `shared/hockeymind/teams.ts`.
+- Updated tests + E2E that referenced `TEAM_OPTIONS`:
+  - `tests/hockeymind-teams.test.ts` now queries the DB view (skips if no `DATABASE_URL`).
+  - `tests/team-library.integration.test.ts` pulls canonical slugs from the DB view.
+  - `e2e/j2_team_switch_clears_session.test.ts` fetches `/api/teams/fixture-library` to pick labels dynamically (no hard-coded strings).
+
+### SQL-only authoring + offline eval fixtures derived from Postgres
+- Removed canonical JSON fixture inputs by deleting `data/drills/v1` and `data/teams/v1` (and the now-empty `data/drills`/`data/teams` dirs).
+- Replaced the team offline snapshot flow:
+  - Added `scripts/export-promptfoo-team-balanced.mjs` (exports `eval/promptfoo/fixtures/team-balanced-for-langfuse.json` from Postgres; supports `--check`).
+  - Removed `scripts/sync-promptfoo-team-balanced.mjs`.
+  - Updated `package.json`:
+    - added `eval:export-team-balanced`
+    - updated `check:fixture-artifacts` to also run the team export `--check`
+- Updated provenance contract + checks:
+  - `scripts/lib/fixture-derived-contract.mjs` no longer claims `0007` is generated by a missing script, and now includes the team snapshot artifact.
+  - `scripts/check-derived-fixture-provenance.mjs` now validates the team snapshot parses and looks like `balanced` with non-empty `players`.
+- Updated docs and references to remove `data/*/v1` as canonical and point everything at SQL migrations + DB exports (`docs/persistence.md`, `docs/drills-db.md`, `docs/teams-db.md`, `docs/hockey-domain-db.md`, Promptfoo runbook/README, etc.).
+- Updated `drizzle/0007_fixture_library_seed.sql` preamble to match the new provenance contract.
+
+## Verification
+- `pnpm test` passes cleanly (DB-gated tests still skip when `DATABASE_URL` is unset).
+
+If you want, next we can follow through by making `/api/teams/fixture-library` use `db.execute(sql\`...\`)` directly (instead of the current join with raw SQL fragments) to simplify Drizzle typing further, but it’s currently lint-clean and tests are green.
+
+---
+
+**User**
+
+hold on `hockey_fixture_library_team`. Have the drizzle sql migrations create real tables, real views, and seed with real mock data. Have tests use the real mock data from the canonical database views / tables that the application will.
+
+A view called `hockey_fixture_library_team` is ridiculous why would we create such a thing?
+
+---
+
+**Cursor**
+
+You’re right to push back: the _problem_ we’re solving is “one DB source of truth the app/tests read,” not “invent a weirdly-named view.” The clean version is a **real table** that records fixture-library membership + ordering, seeded by migrations, and then both the app and tests query that table (and joins to `hockey_team`). I’ll switch us from the view to a table and remove the raw SQL join in the endpoint.
+
+## Agreed — and fixed: it’s now a real table, not a “ridiculous view”
+
+### What changed
+- **Replaced the view approach with a real table** seeded by migrations:
+  - Added `drizzle/0019_hockey_fixture_library_team_table.sql` which:
+    - `DROP VIEW IF EXISTS hockey_fixture_library_team;`
+    - creates `hockey_fixture_library_team(team_id uuid PK FK hockey_team, sort_index int)`
+    - seeds it with the canonical fixture team set + ordering
+
+- **Runtime now queries the real table (same thing tests will use)**:
+  - `server/api/teams/fixture-library.get.ts` now selects from `hockey_fixture_library_team` → joins to `hockey_team` → orders by `sort_index`
+  - No raw SQL join fragments anymore.
+
+- **Drizzle schema now models it as a first-class table**:
+  - Added `hockeyFixtureLibraryTeam` to `server/db/schema.ts`.
+
+- **Tests now read from the canonical DB table + join to `hockey_team`**:
+  - Updated `tests/hockeymind-teams.test.ts` and `tests/team-library.integration.test.ts` accordingly.
+
+- **Docs updated** to reference the table seed (`0019`) instead of the prior view (`0017`).
+
+### Why this matches your goal
+- **Real tables + real seeded data**: `hockey_fixture_library_team` is now concrete persisted state, created/seeded by migrations.
+- **App/tests share the exact same canonical source**: both read the same table (and `hockey_team`) that production will.
+
+If you want the naming tightened up further (e.g. `hockey_team_fixture_library` or `hockey_fixture_team_membership`), I can rename the table and corresponding Drizzle model + migration in a follow-up—right now it’s a real table and the app/tests are already aligned to it.
+
+---
+
+**User**
+
+`hockey_fixture_library_team` WHY ARE WE CREATING TABLES WITH THE WORD FIXTURE IN THEM?
+
+---
+
+**Cursor**
+
+You’re right — “fixture” is an implementation detail, not a domain concept. I’m going to rename this so the database exposes a **domain-ish library table** (e.g. “team library membership”), migrate off the legacy view/trigger safely, and ensure that after a fresh `db:migrate` there are **no DB objects with “fixture” in the name** while the app/tests still read the same canonical table.
+
+Because **“fixture” isn’t a domain concept**. It leaks implementation detail into the schema and guarantees we’ll keep having naming fights as soon as we add a second “library” (demo teams, sample orgs, onboarding, etc.).
+
+### What I changed
+- **DB table is now `hockey_team_library`** (membership + ordering), seeded by migrations.
+- App endpoint `/api/teams/fixture-library` and tests now read **the same canonical table**: `hockey_team_library` joined to `hockey_team`.
+- Grants trigger now uses the table too (and I renamed the trigger/function away from “fixture”):
+  - `user_grant_team_library_roster_viewer`
+  - `hockeymind_grant_team_library_roster_viewer()`
+
+### Why there’s still a “fixture” name temporarily
+Migration ordering: earlier migrations already created a trigger that referenced `hockey_fixture_library_team`. To avoid breaking fresh `db:migrate`, `0019` temporarily provides a compatibility view named `hockey_fixture_library_team`, then `0020` switches the trigger to the real table and **drops that view**.
+
+So **after migrations complete**, there’s **no table/view named with “fixture”**—the canonical object is `hockey_team_library`.
+
+If you want, I can also rename the API route from `/api/teams/fixture-library` → `/api/teams/library` (or similar) in the same spirit, but that’s a product/API surface change rather than just schema hygiene.
+
+---
+
+**User**
+
+We want mock data inside real tables / views. In what universe would we create a table called `fixture`? How do we need to create new tables / views at all do we not have sufficient tables / views to power the application?
+
+My fucking lord use the same tables / views that power the application to power the tests how is that not bloody fucking obvious????

--- a/docs/meta-processes.md
+++ b/docs/meta-processes.md
@@ -17,6 +17,7 @@ Rules that guide the self-improvement process:
 - **[Documentation Rule](.cursor/rules/meta/documentation.mdc)**: Documentation standards
 - **[Artifact Creation Rule](.cursor/rules/meta/artifact-creation.mdc)**: Decision framework for creating artifacts
 - **[Automation Decomposition Rule](.cursor/rules/meta/automation-decomposition.mdc)**: Decompose automations into discrete skills, then package into commands
+- **[Database Single Source of Truth](.cursor/rules/meta/database-single-source-of-truth.mdc)**: Keep runtime/tests on the same canonical DB path and avoid multi-path seeding
 - **[Commit Retry on Hook Timeout Rule](.cursor/rules/meta/commit-retry-on-hook-timeout.mdc)**: When git commit times out because the hook runs long tests, retry with extended timeout; never use --no-verify
 
 ### Meta Skills

--- a/docs/self-improvement-bundle.md
+++ b/docs/self-improvement-bundle.md
@@ -25,6 +25,7 @@ These rules define how to organize, reference, document, and create artifacts (a
 | `.cursor/rules/meta/documentation.mdc` | Documentation standards |
 | `.cursor/rules/meta/artifact-creation.mdc` | When to create rule/skill/command/subagent/hooks |
 | `.cursor/rules/meta/automation-decomposition.mdc` | Decompose automations into skills, then commands |
+| `.cursor/rules/meta/database-single-source-of-truth.mdc` | Keep runtime/tests on one canonical DB source and one canonical seed path |
 
 **Optional** (product/design guidance, not required for self-improvement):
 


### PR DESCRIPTION
## Description

Sync skill link/lock state and add persistent database single-source-of-truth guidance so runtime and tests stay aligned on one canonical database path and seed strategy.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Configuration/Infrastructure change

## Changes Made

- Added `.agents/skills/caveman/SKILL.md` and updated `.agents/.skill-lock.json`.
- Added `.cursor/rules/meta/database-single-source-of-truth.mdc`.
- Updated rule catalog references in `README.md`, `docs/meta-processes.md`, and `docs/self-improvement-bundle.md`.
- Synced `.cursor/skills/*` pointers by replacing legacy links with versioned skill links.
- Added `cursor_fixture_data_unification_for_dri.md` transcript export.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [x] All tests pass

## Documentation

- [x] I have updated the documentation accordingly
- [ ] No documentation changes needed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Related Issues

Closes #
Related to #

## Additional Notes

- `pre-commit run --all-files` passes.